### PR TITLE
fix(ci): Add necessary permissions for SonarQube in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+        permissions:
+      contents: read
+      pull-requests: write
+      checks: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
-        permissions:
+    permissions:
       contents: read
       pull-requests: write
       checks: write
@@ -38,7 +38,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
-
         with:
           args: >
             -Dsonar.projectKey=etl_hs-osnabruck-etl


### PR DESCRIPTION
Added explicit permissions to the SonarQube job in the GitHub Actions workflow to ensure proper access control:
- `contents: read` for repository checkout
- `pull-requests: write` to allow SonarQube comments on PRs
- `checks: write` to update check runs

Closes #20 